### PR TITLE
Allow urlPath override for httpAdapter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -97,14 +97,18 @@ class DSHttpAdapter {
   getPath(method, resourceConfig, id, options) {
     let _this = this;
     options = options || {};
-    let args = [
-      options.basePath || _this.defaults.basePath || resourceConfig.basePath,
-      this.getEndpoint(resourceConfig, (isString(id) || isNumber(id) || method === 'create') ? id : null, options)
-    ];
-    if (method === 'find' || method === 'update' || method === 'destroy') {
-      args.push(id);
+    if (isString(options.urlPath)) {
+      return makePath.apply(DSUtils, [options.basePath || _this.defaults.basePath || resourceConfig.basePath, options.urlPath.split('/')]);
+    } else {
+      let args = [
+        options.basePath || _this.defaults.basePath || resourceConfig.basePath,
+        this.getEndpoint(resourceConfig, (isString(id) || isNumber(id) || method === 'create') ? id : null, options)
+      ];
+      if (method === 'find' || method === 'update' || method === 'destroy') {
+        args.push(id);
+      }
+      return makePath.apply(DSUtils, args);
     }
-    return makePath.apply(DSUtils, args);
   }
 
   HTTP(config) {
@@ -289,4 +293,3 @@ class DSHttpAdapter {
 }
 
 module.exports = DSHttpAdapter;
-


### PR DESCRIPTION
This PR allows you to specify a `urlPath` option when running an async method.

Example:

```javascript
store.filter('customer', myQueryParams, {urlPath: '/report/specialPath'}).then(function (result) {
  console.log(result)
})
```