### PR TITLE
Test Coverage (fetch, updateMany/createMany, addAction(s))

### DIFF
--- a/fetch/karma.conf.js
+++ b/fetch/karma.conf.js
@@ -52,6 +52,7 @@ module.exports = function (config) {
     browsers: browsers,
     files: [
       'node_modules/babel-polyfill/dist/polyfill.js',
+      'node_modules/whatwg-fetch/fetch.js',
       'node_modules/js-data/dist/js-data.js',
       'fetch/dist/js-data-fetch.js',
       'fetch/karma.start.js',

--- a/fetch/karma.start.js
+++ b/fetch/karma.start.js
@@ -15,6 +15,7 @@ before(function () {
   Test.sinon = sinon
   Test.JSData = JSData
   Test.addAction = JSDataHttp.addAction
+  Test.addActions = JSDataHttp.addActions
   Test.HttpAdapter = JSDataHttp.HttpAdapter
   Test.User = new JSData.Mapper({
     name: 'user'

--- a/fetch/karma.start.js
+++ b/fetch/karma.start.js
@@ -14,6 +14,7 @@ before(function () {
   }
   Test.sinon = sinon
   Test.JSData = JSData
+  Test.addAction = JSDataHttp.addAction
   Test.HttpAdapter = JSDataHttp.HttpAdapter
   Test.User = new JSData.Mapper({
     name: 'user'

--- a/fetch/karma.start.js
+++ b/fetch/karma.start.js
@@ -17,6 +17,11 @@ before(function () {
   Test.addAction = JSDataHttp.addAction
   Test.addActions = JSDataHttp.addActions
   Test.HttpAdapter = JSDataHttp.HttpAdapter
+
+  Test.store = new JSData.DataStore()
+  Test.adapter = new Test.HttpAdapter()
+  Test.store.registerAdapter('http', Test.adapter, { default: true })
+
   Test.User = new JSData.Mapper({
     name: 'user'
   })
@@ -26,14 +31,13 @@ before(function () {
     basePath: 'api'
   })
 
+  Test.User.registerAdapter('http', Test.adapter, { default: true })
+  Test.Post.registerAdapter('http', Test.adapter, { default: true })
   console.log('Testing against js-data ' + JSData.version.full)
 })
 
 beforeEach(function () {
   var Test = this
-  Test.adapter = new Test.HttpAdapter()
-  Test.User.registerAdapter('http', Test.adapter, { default: true })
-  Test.Post.registerAdapter('http', Test.adapter, { default: true })
 
   Test.p1 = { author: 'John', age: 30, id: 5 }
   Test.p2 = { author: 'Sally', age: 31, id: 6 }

--- a/fetch/karma.start.js
+++ b/fetch/karma.start.js
@@ -1,6 +1,8 @@
 /* global JSData:true, JSDataHttp:true, sinon:true, chai:true */
+
 before(function () {
   var Test = this
+  Test.TEST_FETCH = true
   Test.fail = function (msg) {
     if (msg instanceof Error) {
       console.log(msg.stack)

--- a/fetch/package.json
+++ b/fetch/package.json
@@ -18,8 +18,7 @@
     "axios",
     "rest",
     "adapter",
-    "http",
-    "fetch"
+    "http"
   ],
   "dependencies": {
     "js-data-adapter": "~0.8.1"

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -52,6 +52,7 @@ module.exports = function (config) {
     browsers: browsers,
     files: [
       'node_modules/babel-polyfill/dist/polyfill.js',
+      'node_modules/whatwg-fetch/fetch.js',
       'node_modules/js-data/dist/js-data.js',
       'dist/js-data-http.js',
       'karma.start.js',

--- a/karma.start.js
+++ b/karma.start.js
@@ -15,6 +15,7 @@ before(function () {
   Test.sinon = sinon
   Test.JSData = JSData
   Test.addAction = JSDataHttp.addAction
+  Test.addActions = JSDataHttp.addActions
   Test.HttpAdapter = JSDataHttp.HttpAdapter
   Test.User = new JSData.Mapper({
     name: 'user'

--- a/karma.start.js
+++ b/karma.start.js
@@ -14,6 +14,7 @@ before(function () {
   }
   Test.sinon = sinon
   Test.JSData = JSData
+  Test.addAction = JSDataHttp.addAction
   Test.HttpAdapter = JSDataHttp.HttpAdapter
   Test.User = new JSData.Mapper({
     name: 'user'

--- a/karma.start.js
+++ b/karma.start.js
@@ -1,6 +1,8 @@
 /* global JSData:true, JSDataHttp:true, sinon:true, chai:true */
+
 before(function () {
   var Test = this
+  Test.TEST_FETCH = false
   Test.fail = function (msg) {
     if (msg instanceof Error) {
       console.log(msg.stack)

--- a/karma.start.js
+++ b/karma.start.js
@@ -17,6 +17,12 @@ before(function () {
   Test.addAction = JSDataHttp.addAction
   Test.addActions = JSDataHttp.addActions
   Test.HttpAdapter = JSDataHttp.HttpAdapter
+
+  Test.store = new JSData.DataStore()
+  Test.adapter = new Test.HttpAdapter()
+
+  Test.store.registerAdapter('http', Test.adapter, { default: true })
+
   Test.User = new JSData.Mapper({
     name: 'user'
   })
@@ -26,14 +32,13 @@ before(function () {
     basePath: 'api'
   })
 
+  Test.User.registerAdapter('http', Test.adapter, { default: true })
+  Test.Post.registerAdapter('http', Test.adapter, { default: true })
   console.log('Testing against js-data ' + JSData.version.full)
 })
 
 beforeEach(function () {
   var Test = this
-  Test.adapter = new Test.HttpAdapter()
-  Test.User.registerAdapter('http', Test.adapter, { default: true })
-  Test.Post.registerAdapter('http', Test.adapter, { default: true })
 
   Test.p1 = { author: 'John', age: 30, id: 5 }
   Test.p2 = { author: 'Sally', age: 31, id: 6 }

--- a/node/mocha.start.js
+++ b/node/mocha.start.js
@@ -21,6 +21,10 @@ before(function () {
   Test.addAction = require('./dist/js-data-http-node').addAction
   Test.addActions = require('./dist/js-data-http-node').addActions
   Test.HttpAdapter = require('./dist/js-data-http-node').HttpAdapter
+  Test.store = new Test.JSData.DataStore()
+  Test.adapter = new Test.HttpAdapter()
+  Test.store.registerAdapter('http', Test.adapter, { default: true })
+
   Test.User = new Test.JSData.Mapper({
     name: 'user'
   })
@@ -30,15 +34,13 @@ before(function () {
     basePath: 'api'
   })
 
+  Test.User.registerAdapter('http', Test.adapter, { default: true })
+  Test.Post.registerAdapter('http', Test.adapter, { default: true })
   console.log('Testing against js-data ' + Test.JSData.version.full)
 })
 
 beforeEach(function () {
   var Test = this
-  Test.adapter = new Test.HttpAdapter()
-  Test.User.registerAdapter('http', Test.adapter, { default: true })
-  Test.Post.registerAdapter('http', Test.adapter, { default: true })
-
   Test.p1 = { author: 'John', age: 30, id: 5 }
   Test.p2 = { author: 'Sally', age: 31, id: 6 }
   Test.p3 = { author: 'Mike', age: 32, id: 7 }

--- a/node/mocha.start.js
+++ b/node/mocha.start.js
@@ -19,6 +19,7 @@ before(function () {
   Test.sinon = require('sinon')
   Test.JSData = require('js-data')
   Test.addAction = require('./dist/js-data-http-node').addAction
+  Test.addActions = require('./dist/js-data-http-node').addActions
   Test.HttpAdapter = require('./dist/js-data-http-node').HttpAdapter
   Test.User = new Test.JSData.Mapper({
     name: 'user'

--- a/node/mocha.start.js
+++ b/node/mocha.start.js
@@ -18,6 +18,7 @@ before(function () {
   }
   Test.sinon = require('sinon')
   Test.JSData = require('js-data')
+  Test.addAction = require('./dist/js-data-http-node').addAction
   Test.HttpAdapter = require('./dist/js-data-http-node').HttpAdapter
   Test.User = new Test.JSData.Mapper({
     name: 'user'

--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "phantomjs-prebuilt": "2.1.12",
     "rollup-plugin-commonjs": "3.3.1",
     "rollup-plugin-replace": "1.1.1",
-    "uglify-js": "2.7.0"
+    "uglify-js": "2.7.0",
+    "whatwg-fetch": "^1.0.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-/* global fetch:true Headers:true Request:true */
+/* global fetch:true Headers:true */
 
 import {utils} from 'js-data'
 import axios from '../node_modules/axios/dist/axios'
@@ -53,7 +53,7 @@ function buildUrl (url, params) {
     }
 
     val.forEach(function (v) {
-      if (window.toString.call(v) === '[object Date]') {
+      if (toString.call(v) === '[object Date]') {
         v = v.toISOString()
       } else if (utils.isObject(v)) {
         v = utils.toJson(v)
@@ -558,20 +558,19 @@ Adapter.extend({
    * @param {Object} config.headers Headers for the request.
    * @param {Object} config.params Querystring for the request.
    * @param {string} config.url Url for the request.
-   * @param {Object} [opts] Configuration options.
    */
-  fetch (config, opts) {
+  fetch (config) {
     const requestConfig = {
       method: config.method,
       // turn the plain headers object into the Fetch Headers object
-      headers: new Headers(config.headers)
+      headers: new Headers(config.headers || {})
     }
 
     if (config.data) {
       requestConfig.body = utils.toJson(config.data)
     }
 
-    return fetch(new Request(buildUrl(config.url, config.params), requestConfig))
+    return fetch(buildUrl(config.url, config.params), requestConfig)
       .then((response) => {
         response.config = {
           method: config.method,

--- a/src/index.js
+++ b/src/index.js
@@ -969,7 +969,7 @@ Adapter.extend({
   sum (mapper, field, query, opts) {
     query || (query = {})
     opts || (opts = {})
-    if (!utils.utils.isString(field)) {
+    if (!utils.isString(field)) {
       throw new Error('field must be a string!')
     }
     opts.params = this.getParams(opts)

--- a/test/count.test.js
+++ b/test/count.test.js
@@ -1,0 +1,14 @@
+describe('sum', function () {
+  it('should include count=true in query_params', function (done) {
+    var Test = this
+
+    setTimeout(function () {
+      Test.requests[0].respond(200, { 'Content-Type': 'application/json' }, '{"count": 5}')
+    }, 5)
+
+    Test.adapter.count(Test.Post).then(function (result) {
+      Test.assert.equal(Test.requests[0].url, 'api/posts?count=true')
+      done()
+    })
+  })
+})

--- a/test/createMany.test.js
+++ b/test/createMany.test.js
@@ -1,3 +1,17 @@
 describe('createMany', function () {
-  it('should createMany')
+  it('should createMany', function (done) {
+    var Test = this
+
+    setTimeout(function () {
+      Test.requests[0].respond(200, { 'Content-Type': 'application/json' }, '')
+    }, 5)
+
+    var many = [{ author_id: 2, text: 'bar' }, { author_id: 2, text: 'foo' }]
+    Test.Post.createMany(many).then(function (result) {
+      Test.assert.equal(Test.requests[0].url, 'api/posts')
+      Test.assert.equal(Test.requests[0].method, 'POST')
+      Test.assert.equal(Test.requests[0].requestBody, JSON.stringify(many))
+      done()
+    })
+  })
 })

--- a/test/fetch.test.js
+++ b/test/fetch.test.js
@@ -1,3 +1,36 @@
 describe('fetch', function () {
-  it('should fetch')
+  it('should fetch from a URL', function (done) {
+    var Test = this
+    // Don't test fetch for Node
+    try {
+      fetch // eslint-disable-line
+    } catch (e) {
+      return this.skip()
+    }
+    if (Test.TEST_FETCH) {
+      Test.xhr = Test.sinon.useFakeXMLHttpRequest()
+      Test.requests = []
+      Test.xhr.onCreate = function (xhr) {
+        Test.requests.push(xhr)
+      }
+    }
+
+    setTimeout(function () {
+      Test.requests[0].respond(200, { 'Content-Type': 'application/json' }, '{}')
+    }, 300)
+
+    Test.adapter.fetch({
+      method: 'get',
+      params: { active: true },
+      url: '/api/foos'
+    }).then(function (response) {
+      var request = Test.requests[0]
+      Test.assert.equal(request.method, 'GET')
+      Test.assert.equal(request.url, '/api/foos?active=true')
+      if (Test.TEST_FETCH) {
+        Test.xhr.restore()
+      }
+      done()
+    })
+  })
 })

--- a/test/static.addAction.test.js
+++ b/test/static.addAction.test.js
@@ -1,3 +1,60 @@
 describe('static addAction', function () {
-  it('should addAction')
+  it('should addAction', function (done) {
+    var Test = this
+    var adapter = Test.adapter
+    var store = new Test.JSData.DataStore()
+    store.registerAdapter('http', adapter, { default: true })
+    var SchoolMapper = store.defineMapper('school', {})
+
+    // GET async/reports/schools/:school_id/teachers
+    Test.addAction('getTeacherReportsAsync', {
+      basePath: 'async/',
+      endpoint: 'reports/schools',
+      pathname: 'teachers',
+      method: 'GET'
+    })(SchoolMapper)
+
+    setTimeout(function () {
+      Test.requests[0].respond(200, { 'Content-Type': 'text/plain' }, '')
+    }, 5)
+
+    SchoolMapper.getTeacherReportsAsync(1234).then(function (response) {
+      Test.assert.equal(1, Test.requests.length)
+      Test.assert.equal(Test.requests[0].url, 'async/reports/schools/1234/teachers', 'Add action configures basePath, endpoint and pathname')
+      Test.assert.equal(Test.requests[0].method, 'GET')
+      done()
+    })
+  })
+
+  it('addAction action is callable with params instead of id', function (done) {
+    var Test = this
+    var adapter = Test.adapter
+    var store = new Test.JSData.DataStore()
+    store.registerAdapter('http', adapter, { default: true })
+    var SchoolMapper = store.defineMapper('school', {})
+
+    // GET async/reports/schools/teachers
+    Test.addAction('getAllTeacherReportsAsync', {
+      basePath: 'async/',
+      endpoint: 'reports/schools',
+      pathname: 'teachers',
+      method: 'GET'
+    })(SchoolMapper)
+
+    setTimeout(function () {
+      Test.requests[0].respond(200, { 'Content-Type': 'text/plain' }, '')
+    }, 5)
+
+    // GET async/reports/schools/teachers?<key>=<value>
+    SchoolMapper.getAllTeacherReportsAsync({
+      params: {
+        subject: 'esperanto'
+      }
+    }).then(function (response) {
+      Test.assert.equal(1, Test.requests.length)
+      Test.assert.equal(Test.requests[0].url, 'async/reports/schools/teachers?subject=esperanto', 'Add action configures basePath, endpoint, pathname, and querystring')
+      Test.assert.equal(Test.requests[0].method, 'GET')
+      done()
+    })
+  })
 })

--- a/test/static.addAction.test.js
+++ b/test/static.addAction.test.js
@@ -1,10 +1,7 @@
 describe('static addAction', function () {
   it('should addAction', function (done) {
     var Test = this
-    var adapter = Test.adapter
-    var store = new Test.JSData.DataStore()
-    store.registerAdapter('http', adapter, { default: true })
-    var SchoolMapper = store.defineMapper('school', {})
+    var SchoolMapper = Test.store.defineMapper('school', {})
 
     // GET async/reports/schools/:school_id/teachers
     Test.addAction('getTeacherReportsAsync', {

--- a/test/static.addActions.test.js
+++ b/test/static.addActions.test.js
@@ -1,3 +1,51 @@
 describe('static addActions', function () {
-  it('should addActions')
+  it('should addActions', function (done) {
+    var Test = this
+    var adapter = Test.adapter
+    var store = new Test.JSData.DataStore()
+    store.registerAdapter('http', adapter, { default: true })
+    var SchoolMapper = store.defineMapper('school', {})
+
+    // GET async/reports/schools/:school_id/teachers
+    Test.addActions({
+      getTeacherReports: {
+        endpoint: 'reports/schools',
+        pathname: 'teachers',
+        method: 'GET'
+      },
+      getStudentReports: {
+        endpoint: 'reports/schools',
+        pathname: 'students',
+        method: 'GET'
+      }
+    })(SchoolMapper)
+
+    var asyncTestOne = function (nextTest) {
+      setTimeout(function () {
+        Test.requests[0].respond(200, { 'Content-Type': 'text/plain' }, '')
+      }, 5)
+
+      SchoolMapper.getTeacherReports(1234).then(function (response) {
+        Test.assert.equal(1, Test.requests.length)
+        Test.assert.equal(Test.requests[0].url, 'reports/schools/1234/teachers', 'Add action configures basePath, endpoint and pathname')
+        Test.assert.equal(Test.requests[0].method, 'GET')
+        nextTest()
+      })
+    }
+
+    var asyncTestTwo = function () {
+      setTimeout(function () {
+        Test.requests[1].respond(200, { 'Content-Type': 'text/plain' }, '')
+      }, 5)
+
+      SchoolMapper.getStudentReports(1234).then(function (response) {
+        Test.assert.equal(2, Test.requests.length)
+        Test.assert.equal(Test.requests[1].url, 'reports/schools/1234/students', 'Add action configures basePath, endpoint and pathname')
+        Test.assert.equal(Test.requests[1].method, 'GET')
+        done()
+      })
+    }
+
+    asyncTestOne(asyncTestTwo)
+  })
 })

--- a/test/static.addActions.test.js
+++ b/test/static.addActions.test.js
@@ -1,10 +1,7 @@
 describe('static addActions', function () {
   it('should addActions', function (done) {
     var Test = this
-    var adapter = Test.adapter
-    var store = new Test.JSData.DataStore()
-    store.registerAdapter('http', adapter, { default: true })
-    var SchoolMapper = store.defineMapper('school', {})
+    var SchoolMapper = Test.store.defineMapper('school', {})
 
     // GET async/reports/schools/:school_id/teachers
     Test.addActions({

--- a/test/sum.test.js
+++ b/test/sum.test.js
@@ -1,5 +1,14 @@
 describe('sum', function () {
-  it('should #sum on a field', function (done) {
-    done()
+  it('should sum=<field> in query_params', function (done) {
+    var Test = this
+
+    setTimeout(function () {
+      Test.requests[0].respond(200, { 'Content-Type': 'application/json' }, '{"sum": 5}')
+    }, 5)
+
+    Test.adapter.sum(Test.Post, 'num_views').then(function (result) {
+      Test.assert.equal(Test.requests[0].url, 'api/posts?sum=num_views')
+      done()
+    })
   })
 })

--- a/test/sum.test.js
+++ b/test/sum.test.js
@@ -1,0 +1,5 @@
+describe('sum', function () {
+  it('should #sum on a field', function (done) {
+    done()
+  })
+})

--- a/test/updateMany.test.js
+++ b/test/updateMany.test.js
@@ -1,3 +1,17 @@
-describe('updateMany', function () {
-  it('should updateMany')
+describe('createMany', function () {
+  it('should createMany', function (done) {
+    var Test = this
+    var many = [{ author_id: 2, text: 'bar', id: 1 }, { author_id: 2, text: 'foo', id: 2 }]
+
+    setTimeout(function () {
+      Test.requests[0].respond(200, { 'Content-Type': 'application/json' }, JSON.stringify(many))
+    }, 5)
+
+    Test.Post.updateMany(many).then(function (result) {
+      Test.assert.equal(Test.requests[0].url, 'api/posts')
+      Test.assert.equal(Test.requests[0].method, 'PUT')
+      Test.assert.equal(Test.requests[0].requestBody, JSON.stringify(many))
+      done()
+    })
+  })
 })


### PR DESCRIPTION
So not all of the top level `opts` such as `basePath` per docs are getting merged into `_opts` in addAction. The following PR should fix it by missing both of them, also adding a test since addAction was missing coverage. 

A few other things (maybe worth opening an issue for) - one thing I'm not a huge fan of is the large dynamic function definition in `addAction`, it may be nicer to have a static function and either bind, or store some of the default arguments to be passed to it. 

Another is that `addAction` is a function in an extension that relies `mapper` / `store` introspection to be correct. Would a more general path-way to to allow `action: {}` definitions in the `mapper` which the applied / registered adapters be allowed to absorb into their own actions without requiring them to introspect the core framework? 