### PR TITLE
Take basePath from resourceConfig before global defaults

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -108,10 +108,10 @@ class DSHttpAdapter {
     let _this = this
     options || (options = {})
     if (isString(options.urlPath)) {
-      return makePath.apply(DSUtils, [options.basePath || _this.defaults.basePath || resourceConfig.basePath, options.urlPath])
+      return makePath.apply(DSUtils, [options.basePath || resourceConfig.basePath || _this.defaults.basePath, options.urlPath])
     } else {
       let args = [
-        options.basePath || _this.defaults.basePath || resourceConfig.basePath,
+        options.basePath || resourceConfig.basePath || _this.defaults.basePath,
         this.getEndpoint(resourceConfig, (isString(id) || isNumber(id) || method === 'create') ? id : null, options)
       ]
       if (method === 'find' || method === 'update' || method === 'destroy') {


### PR DESCRIPTION
Fixes #70.

- [x] - `npm test` succeeds
- [x] - Pull request has been squashed into 1 commit
- [x] - I did NOT commit changes to `dist/`
- [x] - Code coverage does not decrease (if any source code was changed)
- [x] - Appropriate JSDoc comments were updated in source code (if applicable)
- [x] - Approprate changes to js-data.io docs have been suggested ("Suggest Edits" button)
