### PR TITLE
Fix params blacklist

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -770,7 +770,9 @@ Adapter.extend({
     const payload = config.data
     const cache = config.cache
     const timeout = config.timeout
-    config = utils.copy(config, null, null, null, ['data', 'cache', 'timeout'])
+    const params = config.params
+    config = utils.copy(config, null, null, null, ['data', 'cache', 'timeout', 'params']) // params could have data, cache, timeout
+    config.params = utils.copy(params)
     config = utils.deepMixIn(config, this.httpConfig)
     config.data = payload
     config.cache = cache


### PR DESCRIPTION
Fixes a bug where properties of params with the same name as blacklisted copy properties (data, cache, timeout) would be stripped prior to making the HTTP call.

- [x] - `npm test` succeeds
- [ ] - Pull request has been squashed into 1 commit
- [x] - I did NOT commit changes to `dist/`
- [x] - Code coverage does not decrease (if any source code was changed)
- [x] - Appropriate JSDoc comments were updated in source code (if applicable)
- [x] - Approprate changes to js-data.io docs have been suggested ("Suggest Edits" button)
